### PR TITLE
fix the bug of some gpus are blocked during a training iteration

### DIFF
--- a/src/caffe/layers/cudnn_conv_layer.cu
+++ b/src/caffe/layers/cudnn_conv_layer.cu
@@ -42,6 +42,7 @@ void CuDNNConvolutionLayer<Dtype>::Forward_gpu(
     // stream, by launching an empty kernel into the default (null) stream.
     // NOLINT_NEXT_LINE(whitespace/operators)
     sync_conv_groups<<<1, 1>>>();
+    cudaStreamSynchronize(cudaStreamDefault);
   }
 }
 
@@ -109,6 +110,7 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     // stream, by launching an empty kernel into the default (null) stream.
     // NOLINT_NEXT_LINE(whitespace/operators)
     sync_conv_groups<<<1, 1>>>();
+    cudaStreamSynchronize(cudaStreamDefault);
   }
 }
 


### PR DESCRIPTION
We were using multiple GPUs to train AlexNet and/or GoogleNet on ImageNet dataset. cuDNN was used for acceleration. However, during the backward (sometimes forward), one/some of GPUs are blocked and waiting for receiving gradients from the paired GPU before continuing its work. This phenomenon often happens to parent GPUs in the GPU tree. It dramatically reduces the performance of multi-GPUs training.

![blankissue-multigpus](https://cloud.githubusercontent.com/assets/1230113/16255661/c3503808-3886-11e6-973e-e20e635928b8.png)

We tested with different configurations such as (POWER8 + 2 K40 GPU(s)/no P2P + CUDA 7.0 + cuDNN 3.0)/(POWER8 + up to 8 K80 GPUs/(mix of P2P and non-P2P) + CUDA 8.0/7.5 + cuDNNv5.0)/(x86 + 2 K40 GPUs/P2P + CUDA 7.5 + cuDNNv4.0), and the problem often appears.

We found that the bug is caused by the convolution layer that uses cuDNN (src/caffe/layers/cudnn_conv_layer.cu). In the convolution layer, there are multiple threads created, and Caffe uses an empty kernel to do a synchronization at the end of forward/backward. 

``` C++
// Synchronize the work across groups, each of which went into its own
// stream, by launching an empty kernel into the default (null) stream.
// NOLINT_NEXT_LINE(whitespace/operators)
sync_conv_groups<<<1, 1>>>();
```

In the case of multiple GPUs, after Forward and Backward, the root solver collects gradients from GPUs, and Caffe also uses the default stream to do another synchronization (see the callback function `on_gradients_ready()` in src/caffe/parallel.cpp).

``` C++
CUDA_CHECK(cudaMemcpyAsync(dst, src, size_ * sizeof(Dtype),  //
     cudaMemcpyDeviceToDevice, cudaStreamDefault));
CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
```

However, kernel calls are asynchronous with host as described [here](http://on-demand.gputechconf.com/gtc-express/2011/presentations/StreamsAndConcurrencyWebinar.pdf),
Hence, the `cudaMemcpyAsync` causes an implicit synchronization as described in the section “Implicit Synchronization” in the CUDA C Programming Guide, which blocks a parent GPU from executing threads in the convolution layer and causes it to wait until gradients are exchanged.

To fix this bug, we explicitly do a synchronization after the empty kernels in the file `src/caffe/layers/cudnn_conv_layer.cu`, by inserting a call `cudaStreamSynchronize(cudaStreamDefault)`. By this patch, there is no blocking on GPUs any more, and we can reduce on average about 20% of running time per iteration.

![blankissue-multigpus-fixed](https://cloud.githubusercontent.com/assets/1230113/16260488/9fdfc1ba-38a2-11e6-9421-c06c7488fffa.png)
